### PR TITLE
Pull public keys from GitHub.

### DIFF
--- a/deploy/roles/common/tasks/main.yml
+++ b/deploy/roles/common/tasks/main.yml
@@ -12,3 +12,14 @@
   sudo: yes
   notify:
   - restart sshd
+
+- name: directory to hold public keys
+  file: state=directory path=/tmp/pubkeys mode=0755
+
+- name: fetch public keys from github
+  get_url: dest=/tmp/pubkeys/{{ item }}-pubkeys url=https://github.com/{{ item }}.keys
+  with_items: github_usernames
+
+- name: assemble the authorized keys file
+  assemble: dest=/root/.ssh/authorized_keys mode=0600 src=/tmp/pubkeys
+  sudo: yes

--- a/deploy/vars.yml
+++ b/deploy/vars.yml
@@ -10,5 +10,12 @@ tmpnb_redirect_uri: /notebooks/Nature.ipynb
 tmpnb_command: ipython3 notebook --NotebookApp.base_url={base_path}
 tmpnb_max_dock_workers: 8
 tmpnb_docker_version: 1.13
-tmpnb_cpu_shares: 16 
+tmpnb_cpu_shares: 16
 tmpnb_mem_limit: 512m
+
+# GitHub users to grab public keys from
+
+github_usernames:
+- rgbkrk
+- smashwilson
+- minrk


### PR DESCRIPTION
Derive the root user's authorized keys by pulling from the GitHub API.
