### PR TITLE
Changed default backend to new nbagg

### DIFF
--- a/Nature.ipynb
+++ b/Nature.ipynb
@@ -78,7 +78,7 @@
      "input": [
       "# Import matplotlib (plotting) and numpy (numerical arrays).\n",
       "# This enables their use in the Notebook.\n",
-      "%matplotlib inline\n",
+      "%matplotlib nbagg\n",
       "import matplotlib.pyplot as plt \n",
       "import numpy as np\n",
       "\n",
@@ -146,7 +146,7 @@
      "input": [
       "# Import matplotlib (plotting) and numpy (numerical arrays).\n",
       "# This enables their use in the Notebook.\n",
-      "%matplotlib inline\n",
+      "%matplotlib nbagg\n",
       "import matplotlib.pyplot as plt\n",
       "import numpy as np\n",
       "\n",
@@ -207,7 +207,7 @@
      "input": [
       "# Import matplotlib (plotting), skimage (image processing) and interact (user interfaces)\n",
       "# This enables their use in the Notebook.\n",
-      "%matplotlib inline\n",
+      "%matplotlib nbagg\n",
       "from matplotlib import pyplot as plt\n",
       "\n",
       "from skimage import data\n",


### PR DESCRIPTION
We suggest changing the default backend to the one introduced in matplotlib 1.4. This way one gets basic interactivity in the figure (zooming, panning). We were not able to retain the figure between updates of the widget (i.e. for conserving the figure size), but that would probably require digging into interactive or nbagg thoughts. What do you think?