### PR TITLE
update nature demo notebook to reflect status

### DIFF
--- a/Nature.ipynb
+++ b/Nature.ipynb
@@ -1,7 +1,302 @@
 {
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"clearfix\" style=\"padding: 10px; padding-left: 0px\">\n",
+    "<img src=\"https://cloud.githubusercontent.com/assets/836375/4911394/dd819b7e-648c-11e4-8c6d-755b9d4d9ea3.png\" width=\"150px\" style=\"display: inline-block; margin-top: 5px;\">\n",
+    "<a href=\"http://bit.ly/naturedevplus\"><img src=\"https://cloud.githubusercontent.com/assets/836375/4916141/2732892e-64d6-11e4-980f-11afcf03ca31.png\" width=\"150px\" class=\"pull-right\" style=\"display: inline-block; margin: 0px;\"></a>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<p class=\"alert alert-warning\" role=\"alert\"><strong>Attention!</strong> This is <strong>no longer a live demo</strong>. What follows is the original text from the live Nature demo that ran from November 2014 to March 2017. For up to date installation and usage of the Jupyter Notebook (née IPython notebook), visit <a href=\"https://jupyter.org\">jupyter.org</a></p>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Welcome! You have just launched a live example of an IPython Notebook. The notebook is an open-source, interactive computing environment that lets you combine live code, narrative text, mathematics, plots and rich media in one document. Notebook documents provide a complete reproducible record of a computation and its results and can be shared with colleagues (through, for example, email, web-hosting services such as GitHub, Dropbox, and [nbviewer](http://nbviewer.ipython.org)).\n",
+    "\n",
+    "You can edit anything in this temporary demonstration notebook, including the text you are reading. To see it full-screen, click on the 'Expand' icon in the lower right corner of the frame around this notebook. \n",
+    "\n",
+    "This notebook showcases some of IPython's capabilities for researchers.\n",
+    "\n",
+    "This demonstration is hosted by [Rackspace](http://bit.ly/naturedevplus) and is running on its bare metal offering, [OnMetal](http://www.rackspace.com/cloud/servers/onmetal/). Try out these cloud services yourself through [Rackspace's developer+ page](http://bit.ly/naturedevplus)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Python code and plotting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The box below (known as a code cell) contains the Python code to plot $y=x^2$ over the range $[0,5]$. The blue comments preceded by `#` explain what the code does.\n",
+    "\n",
+    "To run the code:\n",
+    "\n",
+    "1. Click on the cell to select it.\n",
+    "2. Press `SHIFT+ENTER` on your keyboard or press the play button (<button class='fa fa-play icon-play btn btn-xs btn-default'></button>) in the toolbar above.\n",
+    "\n",
+    "A full tutorial for using the notebook interface is available [here](http://nbviewer.ipython.org/github/ipython/ipython/blob/2.x/examples/Notebook/Index.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Import matplotlib (plotting) and numpy (numerical arrays).\n",
+    "# This enables their use in the Notebook.\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt \n",
+    "import numpy as np\n",
+    "\n",
+    "# Create an array of 30 values for x equally spaced from 0 to 5. \n",
+    "x = np.linspace(0, 5, 30)\n",
+    "y = x**2\n",
+    "\n",
+    "# Plot y versus x\n",
+    "fig, ax = plt.subplots(nrows=1, ncols=1)\n",
+    "ax.plot(x, y, color='red')\n",
+    "ax.set_xlabel('x')\n",
+    "ax.set_ylabel('y')\n",
+    "ax.set_title('A simple graph of $y=x^2$');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Above, you should see a plot of $y=x^2$.\n",
+    "\n",
+    "You can edit this code and re-run it. For example, try replacing `y = x**2` with `y=np.sin(x)`. For a list of valid functions, see the [NumPy Reference Manual](http://docs.scipy.org/doc/numpy/reference/routines.math.html). You can also update the plot title and axis labels.\n",
+    "\n",
+    "Text in the plot as well as narrative text in the notebook can contain equations that are formatted using $\\LaTeX$. To edit text written in $\\LaTeX$, double click on the text or press `ENTER` when the text is selected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactive illustration of aliasing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notebooks can also link code and data to user interfaces (such as sliders, checkboxes, dropdowns) that facilitate interactive exploration.\n",
+    "\n",
+    "Aron Ahmadia (Coastal & Hydraulics Laboratory at the US Army Engineer Research and Development Center) and David Ketcheson (King Abdullah University of Science & Technology) created the following example to illustrate the perils of aliasing, which occurs when a rapidly-changing periodic signal is sampled too infrequently, and creates a false impression of the true frequency of the signal. \n",
+    "\n",
+    "Ketcheson explains:\n",
+    "\n",
+    "> \"As an undergraduate, I did some observational astronomy looking at variable stars.\n",
+    "> These are stars whose brightness oscillates, usually on a fairly regular basis. \n",
+    "> Many published results claim to measure how quickly the star's brightness oscillates - \n",
+    "> but actually report the oscillations at some multiple of the real answer, owing to\n",
+    "> insufficient observation and (as a result) aliasing.\"\n",
+    "\n",
+    "This example shows how trying to reconstruct a simple sine wave signal from discrete measurements can fail. The sliders allow you to adjust the frequency of the underlying periodic sine wave signal (represented by `frequency`), and also how often the signal is sampled (represented by `grid_points`). Get it wrong, and a high-frequency sine wave is measured as a lower-frequency signal.\n",
+    "\n",
+    "To see the effects of aliasing:\n",
+    "\n",
+    "1. Run the next cell, then set the `grid_points` slider to `13`.\n",
+    "2. Move the `frequency` slider to values above `10`.\n",
+    "3. As the frequency increases, the measured signal (blue) has a lower frequency than the real one (red)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Import matplotlib (plotting) and numpy (numerical arrays).\n",
+    "# This enables their use in the Notebook.\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# Import IPython's interact function which is used below to\n",
+    "# build the interactive widgets\n",
+    "from IPython.html.widgets import interact\n",
+    "\n",
+    "def plot_sine(frequency=4.0, grid_points=12, plot_original=True):\n",
+    "    \"\"\"\n",
+    "    Plot discrete samples of a sine wave on the interval ``[0, 1]``.\n",
+    "    \"\"\"\n",
+    "    x = np.linspace(0, 1, grid_points + 2)\n",
+    "    y = np.sin(2 * frequency * np.pi * x)\n",
+    "\n",
+    "    xf = np.linspace(0, 1, 1000)\n",
+    "    yf = np.sin(2 * frequency * np.pi * xf)\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "    ax.set_xlabel('x')\n",
+    "    ax.set_ylabel('signal')\n",
+    "    ax.set_title('Aliasing in discretely sampled periodic signal')\n",
+    "\n",
+    "    if plot_original:\n",
+    "        ax.plot(xf, yf, color='red', linestyle='solid', linewidth=2)\n",
+    "\n",
+    "    ax.plot(x,  y,  marker='o', linewidth=2)\n",
+    "\n",
+    "# The interact function automatically builds a user interface for exploring the\n",
+    "# plot_sine function.\n",
+    "interact(plot_sine, frequency=(1.0, 22.0, 0.5), grid_points=(10, 16, 1), plot_original=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Counting galaxies in the Hubble deep field"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The notebook can utilize powerful Python libraries that span everything from statistics and machine learning to signal and image processing. This example uses the image-processing library [scikit-image](http://scikit-image.org/) to identify galaxies in an image of the sky provided by the Hubble Space Telescope using a blob feature detection algorithm (an approach known as the [determinant of Hessian](http://en.wikipedia.org/wiki/Blob_detection#The_determinant_of_the_Hessian) ).\n",
+    "\n",
+    "After running the cell, you can play with the parameters of the detection algorithm to find galaxies of different sizes and prominences:\n",
+    "\n",
+    "* The `max_sigma` parameter determines the maximum size of the objects that will be identified.\n",
+    "* The `threshold` parameter can be reduced to detect less prominent objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Import matplotlib (plotting), skimage (image processing) and interact (user interfaces)\n",
+    "# This enables their use in the Notebook.\n",
+    "%matplotlib inline\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "from skimage import data\n",
+    "from skimage.feature import blob_doh\n",
+    "from skimage.color import rgb2gray\n",
+    "\n",
+    "from IPython.html.widgets import interact, fixed\n",
+    "\n",
+    "# Extract the first 500px square of the Hubble Deep Field.\n",
+    "image = data.hubble_deep_field()[0:500, 0:500]\n",
+    "image_gray = rgb2gray(image)\n",
+    "\n",
+    "def plot_blobs(max_sigma=30, threshold=0.1, gray=False):\n",
+    "    \"\"\"\n",
+    "    Plot the image and the blobs that have been found.\n",
+    "    \"\"\"\n",
+    "    blobs = blob_doh(image_gray, max_sigma=max_sigma, threshold=threshold)\n",
+    "    \n",
+    "    fig, ax = plt.subplots(figsize=(8,8))\n",
+    "    ax.set_title('Galaxies in the Hubble Deep Field')\n",
+    "    \n",
+    "    if gray:\n",
+    "        ax.imshow(image_gray, interpolation='nearest', cmap='gray_r')\n",
+    "        circle_color = 'red'\n",
+    "    else:\n",
+    "        ax.imshow(image, interpolation='nearest')\n",
+    "        circle_color = 'yellow'\n",
+    "    for blob in blobs:\n",
+    "        y, x, r = blob\n",
+    "        c = plt.Circle((x, y), r, color=circle_color, linewidth=2, fill=False)\n",
+    "        ax.add_patch(c)\n",
+    "\n",
+    "# Use interact to explore the galaxy detection algorithm.\n",
+    "interact(plot_blobs, max_sigma=(10, 40, 2), threshold=(0.005, 0.02, 0.001));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebooks for academic publications"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IPython notebooks are being distributed as supplementary materials in peer-reviewed academic publications to enable readers to reproduce the computational aspects of the work. Here are three prominent examples:\n",
+    "\n",
+    "* Gross, A. M. *et al*., *[Multi-tiered genomic analysis of head and neck cancer ties TP53 mutation to 3p loss]( http://www.nature.com/ng/journal/v46/n9/full/ng.3051.html)*, *Nature Genet.* **46**, 939–943 (2014). (A GitHub repository with all the notebooks required to reproduce this analysis can be found [here](https://github.com/theandygross/TCGA/tree/master/Analysis_Notebooks#guide-to-running). The notebooks can be viewed directly [here](http://nbviewer.ipython.org/github/theandygross/TCGA/tree/master/Analysis_Notebooks/).\n",
+    "* Ragan-Kelley, B. *et al*., *[Collaborative cloud-enabled tools allow rapid, reproducible biological insights](http://www.nature.com/ismej/journal/v7/n3/full/ismej2012123a.html)*, *ISME* **7**, 461–464 (2013). [Supplementary notebook](http://nbviewer.ipython.org/gist/gregcaporaso/3693491/cloud_demo_complete.ipynb)\n",
+    "* Ding, T. & Schloss, T. D. *[Dynamics and associations of microbial community types across the human body](http://www.nature.com/nature/journal/v509/n7500/full/nature13178.html)*, *Nature* **509**, 357–360 (2014). [Supplementary notebook](http://nbviewer.ipython.org/gist/pschloss/9815766/notebook.ipynb)\n",
+    "\n",
+    "A longer list of peer-reviewed publications that have supplementary notebooks can be found [here](https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks#reproducible-academic-publications).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The IPython Project maintains a curated list of notebooks that provide examples of its use across a wide range of fields and topics. You can find these examples at [this gallery](https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks).\n",
+    "\n",
+    "Directions on how to install software to run the IPython notebook on your own computer can be found [here](http://ipython.org/install.html).\n",
+    "\n",
+    "It is also possible to run a notebook in the cloud, without installing the software, using the following services:\n",
+    "\n",
+    "* [Authorea](https://www.authorea.com/)\n",
+    "* [Sage Math Cloud](https://cloud.sagemath.com/)\n",
+    "* [Wakari](https://wakari.io/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The notebook is being moved into a project called Jupyter, which aims to make the IPython software package more compatible with other languages, including Julia and R. Further information can be found on the [IPython](http://ipython.org/install.html) and [Jupyter](http://jupyter.org) websites.\n",
+    "\n",
+    "<img src=\"https://raw.githubusercontent.com/jupyter/nature-demo/master/images/ipython-logo.png\" width=\"250px\" style=\"margin: 20px auto;\">\n",
+    "<img src=\"https://raw.githubusercontent.com/jupyter/nature-demo/master/images/jupyter-logo.png\" width=\"250px\" style=\"margin: 20px auto;\">\n",
+    "\n",
+    "The IPython and Jupyter projects are sponsored by the Alfred P. Sloan Foundation, Rackspace, Google, Microsoft, the National Science Foundation and the Simons Foundation.\n",
+    "\n",
+    "This demonstration was created with the help of: Kyle Kelley, Brian Granger, Fernando Perez, Matthias Bussonnier, Aron Ahmadia, David Ketcheson, Chris Ryan, Richard Van Noorden and Stéfan van der Walt."
+   ]
+  }
+ ],
  "metadata": {
   "kernelspec": {
-   "display_name": "IPython (Python 3)",
+   "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -9,302 +304,14 @@
     "name": "ipython",
     "version": 3
    },
+   "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
-  },
-  "name": "",
-  "signature": "sha256:1e6a685a847be8bd76023ace24d54cef7e423005a26dd712fdc29829167ddb5b"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
-  {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "<div class=\"clearfix\" style=\"padding: 10px; padding-left: 0px\">\n",
-      "<img src=\"https://cloud.githubusercontent.com/assets/836375/4911394/dd819b7e-648c-11e4-8c6d-755b9d4d9ea3.png\" width=\"150px\" style=\"display: inline-block; margin-top: 5px;\">\n",
-      "<a href=\"http://bit.ly/naturedevplus\"><img src=\"https://cloud.githubusercontent.com/assets/836375/4916141/2732892e-64d6-11e4-980f-11afcf03ca31.png\" width=\"150px\" class=\"pull-right\" style=\"display: inline-block; margin: 0px;\"></a>\n",
-      "</div>"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Introduction"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Welcome! You have just launched a live example of an IPython Notebook. The notebook is an open-source, interactive computing environment that lets you combine live code, narrative text, mathematics, plots and rich media in one document. Notebook documents provide a complete reproducible record of a computation and its results and can be shared with colleagues (through, for example, email, web-hosting services such as GitHub, Dropbox, and [nbviewer](http://nbviewer.ipython.org)).\n",
-      "\n",
-      "You can edit anything in this temporary demonstration notebook, including the text you are reading. To see it full-screen, click on the 'Expand' icon in the lower right corner of the frame around this notebook. \n",
-      "\n",
-      "This notebook showcases some of IPython's capabilities for researchers.\n",
-      "\n",
-      "This demonstration is hosted by [Rackspace](http://bit.ly/naturedevplus) and is running on its bare metal offering, [OnMetal](http://www.rackspace.com/cloud/servers/onmetal/). Try out these cloud services yourself through [Rackspace's developer+ page](http://bit.ly/naturedevplus)."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Basic Python code and plotting"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The box below (known as a code cell) contains the Python code to plot $y=x^2$ over the range $[0,5]$. The blue comments preceded by `#` explain what the code does.\n",
-      "\n",
-      "To run the code:\n",
-      "\n",
-      "1. Click on the cell to select it.\n",
-      "2. Press `SHIFT+ENTER` on your keyboard or press the play button (<button class='fa fa-play icon-play btn btn-xs btn-default'></button>) in the toolbar above.\n",
-      "\n",
-      "A full tutorial for using the notebook interface is available [here](http://nbviewer.ipython.org/github/ipython/ipython/blob/2.x/examples/Notebook/Index.ipynb)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Import matplotlib (plotting) and numpy (numerical arrays).\n",
-      "# This enables their use in the Notebook.\n",
-      "%matplotlib inline\n",
-      "import matplotlib.pyplot as plt \n",
-      "import numpy as np\n",
-      "\n",
-      "# Create an array of 30 values for x equally spaced from 0 to 5. \n",
-      "x = np.linspace(0, 5, 30)\n",
-      "y = x**2\n",
-      "\n",
-      "# Plot y versus x\n",
-      "fig, ax = plt.subplots(nrows=1, ncols=1)\n",
-      "ax.plot(x, y, color='red')\n",
-      "ax.set_xlabel('x')\n",
-      "ax.set_ylabel('y')\n",
-      "ax.set_title('A simple graph of $y=x^2$');"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Above, you should see a plot of $y=x^2$.\n",
-      "\n",
-      "You can edit this code and re-run it. For example, try replacing `y = x**2` with `y=np.sin(x)`. For a list of valid functions, see the [NumPy Reference Manual](http://docs.scipy.org/doc/numpy/reference/routines.math.html). You can also update the plot title and axis labels.\n",
-      "\n",
-      "Text in the plot as well as narrative text in the notebook can contain equations that are formatted using $\\LaTeX$. To edit text written in $\\LaTeX$, double click on the text or press `ENTER` when the text is selected."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Interactive illustration of aliasing"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Notebooks can also link code and data to user interfaces (such as sliders, checkboxes, dropdowns) that facilitate interactive exploration.\n",
-      "\n",
-      "Aron Ahmadia (Coastal & Hydraulics Laboratory at the US Army Engineer Research and Development Center) and David Ketcheson (King Abdullah University of Science & Technology) created the following example to illustrate the perils of aliasing, which occurs when a rapidly-changing periodic signal is sampled too infrequently, and creates a false impression of the true frequency of the signal. \n",
-      "\n",
-      "Ketcheson explains:\n",
-      "\n",
-      "> \"As an undergraduate, I did some observational astronomy looking at variable stars.\n",
-      "> These are stars whose brightness oscillates, usually on a fairly regular basis. \n",
-      "> Many published results claim to measure how quickly the star's brightness oscillates - \n",
-      "> but actually report the oscillations at some multiple of the real answer, owing to\n",
-      "> insufficient observation and (as a result) aliasing.\"\n",
-      "\n",
-      "This example shows how trying to reconstruct a simple sine wave signal from discrete measurements can fail. The sliders allow you to adjust the frequency of the underlying periodic sine wave signal (represented by `frequency`), and also how often the signal is sampled (represented by `grid_points`). Get it wrong, and a high-frequency sine wave is measured as a lower-frequency signal.\n",
-      "\n",
-      "To see the effects of aliasing:\n",
-      "\n",
-      "1. Run the next cell, then set the `grid_points` slider to `13`.\n",
-      "2. Move the `frequency` slider to values above `10`.\n",
-      "3. As the frequency increases, the measured signal (blue) has a lower frequency than the real one (red)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Import matplotlib (plotting) and numpy (numerical arrays).\n",
-      "# This enables their use in the Notebook.\n",
-      "%matplotlib inline\n",
-      "import matplotlib.pyplot as plt\n",
-      "import numpy as np\n",
-      "\n",
-      "# Import IPython's interact function which is used below to\n",
-      "# build the interactive widgets\n",
-      "from IPython.html.widgets import interact\n",
-      "\n",
-      "def plot_sine(frequency=4.0, grid_points=12, plot_original=True):\n",
-      "    \"\"\"\n",
-      "    Plot discrete samples of a sine wave on the interval ``[0, 1]``.\n",
-      "    \"\"\"\n",
-      "    x = np.linspace(0, 1, grid_points + 2)\n",
-      "    y = np.sin(2 * frequency * np.pi * x)\n",
-      "\n",
-      "    xf = np.linspace(0, 1, 1000)\n",
-      "    yf = np.sin(2 * frequency * np.pi * xf)\n",
-      "\n",
-      "    fig, ax = plt.subplots(figsize=(8, 6))\n",
-      "    ax.set_xlabel('x')\n",
-      "    ax.set_ylabel('signal')\n",
-      "    ax.set_title('Aliasing in discretely sampled periodic signal')\n",
-      "\n",
-      "    if plot_original:\n",
-      "        ax.plot(xf, yf, color='red', linestyle='solid', linewidth=2)\n",
-      "\n",
-      "    ax.plot(x,  y,  marker='o', linewidth=2)\n",
-      "\n",
-      "# The interact function automatically builds a user interface for exploring the\n",
-      "# plot_sine function.\n",
-      "interact(plot_sine, frequency=(1.0, 22.0, 0.5), grid_points=(10, 16, 1), plot_original=True);"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Counting galaxies in the Hubble deep field"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The notebook can utilize powerful Python libraries that span everything from statistics and machine learning to signal and image processing. This example uses the image-processing library [scikit-image](http://scikit-image.org/) to identify galaxies in an image of the sky provided by the Hubble Space Telescope using a blob feature detection algorithm (an approach known as the [determinant of Hessian](http://en.wikipedia.org/wiki/Blob_detection#The_determinant_of_the_Hessian) ).\n",
-      "\n",
-      "After running the cell, you can play with the parameters of the detection algorithm to find galaxies of different sizes and prominences:\n",
-      "\n",
-      "* The `max_sigma` parameter determines the maximum size of the objects that will be identified.\n",
-      "* The `threshold` parameter can be reduced to detect less prominent objects."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Import matplotlib (plotting), skimage (image processing) and interact (user interfaces)\n",
-      "# This enables their use in the Notebook.\n",
-      "%matplotlib inline\n",
-      "from matplotlib import pyplot as plt\n",
-      "\n",
-      "from skimage import data\n",
-      "from skimage.feature import blob_doh\n",
-      "from skimage.color import rgb2gray\n",
-      "\n",
-      "from IPython.html.widgets import interact, fixed\n",
-      "\n",
-      "# Extract the first 500px square of the Hubble Deep Field.\n",
-      "image = data.hubble_deep_field()[0:500, 0:500]\n",
-      "image_gray = rgb2gray(image)\n",
-      "\n",
-      "def plot_blobs(max_sigma=30, threshold=0.1, gray=False):\n",
-      "    \"\"\"\n",
-      "    Plot the image and the blobs that have been found.\n",
-      "    \"\"\"\n",
-      "    blobs = blob_doh(image_gray, max_sigma=max_sigma, threshold=threshold)\n",
-      "    \n",
-      "    fig, ax = plt.subplots(figsize=(8,8))\n",
-      "    ax.set_title('Galaxies in the Hubble Deep Field')\n",
-      "    \n",
-      "    if gray:\n",
-      "        ax.imshow(image_gray, interpolation='nearest', cmap='gray_r')\n",
-      "        circle_color = 'red'\n",
-      "    else:\n",
-      "        ax.imshow(image, interpolation='nearest')\n",
-      "        circle_color = 'yellow'\n",
-      "    for blob in blobs:\n",
-      "        y, x, r = blob\n",
-      "        c = plt.Circle((x, y), r, color=circle_color, linewidth=2, fill=False)\n",
-      "        ax.add_patch(c)\n",
-      "\n",
-      "# Use interact to explore the galaxy detection algorithm.\n",
-      "interact(plot_blobs, max_sigma=(10, 40, 2), threshold=(0.005, 0.02, 0.001));"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Notebooks for academic publications"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "IPython notebooks are being distributed as supplementary materials in peer-reviewed academic publications to enable readers to reproduce the computational aspects of the work. Here are three prominent examples:\n",
-      "\n",
-      "* Gross, A. M. *et al*., *[Multi-tiered genomic analysis of head and neck cancer ties TP53 mutation to 3p loss]( http://www.nature.com/ng/journal/v46/n9/full/ng.3051.html)*, *Nature Genet.* **46**, 939\u2013943 (2014). (A GitHub repository with all the notebooks required to reproduce this analysis can be found [here](https://github.com/theandygross/TCGA/tree/master/Analysis_Notebooks#guide-to-running). The notebooks can be viewed directly [here](http://nbviewer.ipython.org/github/theandygross/TCGA/tree/master/Analysis_Notebooks/).\n",
-      "* Ragan-Kelley, B. *et al*., *[Collaborative cloud-enabled tools allow rapid, reproducible biological insights](http://www.nature.com/ismej/journal/v7/n3/full/ismej2012123a.html)*, *ISME* **7**, 461\u2013464 (2013). [Supplementary notebook](http://nbviewer.ipython.org/gist/gregcaporaso/3693491/cloud_demo_complete.ipynb)\n",
-      "* Ding, T. & Schloss, T. D. *[Dynamics and associations of microbial community types across the human body](http://www.nature.com/nature/journal/v509/n7500/full/nature13178.html)*, *Nature* **509**, 357\u2013360 (2014). [Supplementary notebook](http://nbviewer.ipython.org/gist/pschloss/9815766/notebook.ipynb)\n",
-      "\n",
-      "A longer list of peer-reviewed publications that have supplementary notebooks can be found [here](https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks#reproducible-academic-publications).\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Next steps"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The IPython Project maintains a curated list of notebooks that provide examples of its use across a wide range of fields and topics. You can find these examples at [this gallery](https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks).\n",
-      "\n",
-      "Directions on how to install software to run the IPython notebook on your own computer can be found [here](http://ipython.org/install.html).\n",
-      "\n",
-      "It is also possible to run a notebook in the cloud, without installing the software, using the following services:\n",
-      "\n",
-      "* [Authorea](https://www.authorea.com/)\n",
-      "* [Sage Math Cloud](https://cloud.sagemath.com/)\n",
-      "* [Wakari](https://wakari.io/)"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The notebook is being moved into a project called Jupyter, which aims to make the IPython software package more compatible with other languages, including Julia and R. Further information can be found on the [IPython](http://ipython.org/install.html) and [Jupyter](http://jupyter.org) websites.\n",
-      "\n",
-      "<img src=\"https://raw.githubusercontent.com/jupyter/nature-demo/master/images/ipython-logo.png\" width=\"250px\" style=\"margin: 20px auto;\">\n",
-      "<img src=\"https://raw.githubusercontent.com/jupyter/nature-demo/master/images/jupyter-logo.png\" width=\"250px\" style=\"margin: 20px auto;\">\n",
-      "\n",
-      "The IPython and Jupyter projects are sponsored by the Alfred P. Sloan Foundation, Rackspace, Google, Microsoft, the National Science Foundation and the Simons Foundation.\n",
-      "\n",
-      "This demonstration was created with the help of: Kyle Kelley, Brian Granger, Fernando Perez, Matthias Bussonnier, Aron Ahmadia, David Ketcheson, Chris Ryan, Richard Van Noorden and St\u00e9fan van der Walt."
-     ]
-    }
-   ],
-   "metadata": {}
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
   }
- ]
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
nature.tmpnb.org now redirects to the nbviewer version of this notebook (done by cloudflare, so it doesn't even matter if the server is up). As part of this, I made the text here reflect that the demo is no longer live and the original text of the notebook is preserved.